### PR TITLE
Fixes #825.

### DIFF
--- a/tests/fixtures/constellix-geofilters.json
+++ b/tests/fixtures/constellix-geofilters.json
@@ -1,34 +1,52 @@
 [
     {
-        "id": 6303, 
-        "name": "some.other", 
-        "filterRulesLimit": 100, 
-        "createdTs": "2021-08-19T14:47:47Z", 
-        "modifiedTs": "2021-08-19T14:47:47Z", 
-        "geoipContinents": ["AS", "OC"], 
+        "id": 1,
+        "name": "World (Default)",
+        "filterRulesLimit": null,
+        "createdTs": null,
+        "modifiedTs": null,
+        "geoipContinents": ["default"],
+        "regions": []
+    },
+    {
+        "id": 6303,
+        "name": "some.other",
+        "filterRulesLimit": 100,
+        "createdTs": "2021-08-19T14:47:47Z",
+        "modifiedTs": "2021-08-19T14:47:47Z",
+        "geoipContinents": ["AS", "OC"],
         "geoipCountries": ["ES", "SE", "UA"],
         "regions": [
             {
-                "continentCode": "NA", 
-                "countryCode": "CA", 
+                "continentCode": "NA",
+                "countryCode": "CA",
                 "regionCode": "NL"
             }
         ]
     },
     {
-        "id": 5303, 
-        "name": "unit.tests.:www.dynamic:A:one", 
-        "filterRulesLimit": 100, 
-        "createdTs": "2021-08-19T14:47:47Z", 
-        "modifiedTs": "2021-08-19T14:47:47Z", 
-        "geoipContinents": ["AS", "OC"], 
+        "id": 5303,
+        "name": "unit.tests.:www.dynamic:A:one",
+        "filterRulesLimit": 100,
+        "createdTs": "2021-08-19T14:47:47Z",
+        "modifiedTs": "2021-08-19T14:47:47Z",
+        "geoipContinents": ["AS", "OC"],
         "geoipCountries": ["ES", "SE", "UA"],
         "regions": [
             {
-                "continentCode": "NA", 
-                "countryCode": "CA", 
+                "continentCode": "NA",
+                "countryCode": "CA",
                 "regionCode": "NL"
             }
         ]
+    },
+    {
+        "id": 9303,
+        "name": "unit.tests.:www.dynamic:A:two",
+        "filterRulesLimit": 100,
+        "createdTs": "2021-08-19T14:47:47Z",
+        "modifiedTs": "2021-08-19T14:47:47Z",
+        "geoipContinents": ["default"],
+        "regions": []
     }
 ]

--- a/tests/fixtures/constellix-records-geo.json
+++ b/tests/fixtures/constellix-records-geo.json
@@ -1,0 +1,81 @@
+[{
+	"id": 1808518,
+	"type": "A",
+	"recordType": "a",
+	"name": "www.geo",
+	"recordOption": "roundRobin",
+	"noAnswer": false,
+	"note": "",
+	"ttl": 300,
+	"gtdRegion": 1,
+	"parentId": 123123,
+	"parent": "domain",
+	"source": "Domain",
+	"modifiedTs": 1565150090588,
+	"value": ["2.2.3.4","2.2.3.5"],
+	"roundRobin": [{
+		"value": "2.2.3.4",
+		"disableFlag": false
+	}, {
+		"value": "2.2.3.5",
+		"disableFlag": false
+	}],
+	"geolocation": {
+		"geoipFilter": 5303
+	},
+	"recordFailover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"failover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"roundRobinFailover": [],
+	"pools": [],
+	"poolsDetail": []
+}, {
+	"id": 1808520,
+	"type": "A",
+	"recordType": "a",
+	"name": "www.geo",
+	"recordOption": "roundRobin",
+	"noAnswer": false,
+	"note": "",
+	"ttl": 300,
+	"gtdRegion": 1,
+	"parentId": 123123,
+	"parent": "domain",
+	"source": "Domain",
+	"modifiedTs": 1565150090588,
+	"value": ["1.2.3.4","1.2.3.5"],
+	"roundRobin": [{
+		"value": "1.2.3.4",
+		"disableFlag": false
+	}, {
+		"value": "1.2.3.5",
+		"disableFlag": false
+	}],
+	"geolocation": {
+		"geoipFilter": 1
+	},
+	"recordFailover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"failover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"roundRobinFailover": [],
+	"pools": [],
+	"poolsDetail": []
+}]

--- a/tests/fixtures/constellix-records-multi-gtd.json
+++ b/tests/fixtures/constellix-records-multi-gtd.json
@@ -1,0 +1,77 @@
+[{
+	"id": 1808518,
+	"type": "A",
+	"recordType": "a",
+	"name": "www.geo",
+	"recordOption": "roundRobin",
+	"noAnswer": false,
+	"note": "",
+	"ttl": 300,
+	"gtdRegion": 1,
+	"parentId": 123123,
+	"parent": "domain",
+	"source": "Domain",
+	"modifiedTs": 1565150090588,
+	"value": ["2.2.3.4","2.2.3.5"],
+	"roundRobin": [{
+		"value": "2.2.3.4",
+		"disableFlag": false
+	}, {
+		"value": "2.2.3.5",
+		"disableFlag": false
+	}],
+	"geolocation": null,
+	"recordFailover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"failover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"roundRobinFailover": [],
+	"pools": [],
+	"poolsDetail": []
+}, {
+	"id": 1808520,
+	"type": "A",
+	"recordType": "a",
+	"name": "www.geo",
+	"recordOption": "roundRobin",
+	"noAnswer": false,
+	"note": "",
+	"ttl": 300,
+	"gtdRegion": 2,
+	"parentId": 123123,
+	"parent": "domain",
+	"source": "Domain",
+	"modifiedTs": 1565150090588,
+	"value": ["1.2.3.4","1.2.3.5"],
+	"roundRobin": [{
+		"value": "1.2.3.4",
+		"disableFlag": false
+	}, {
+		"value": "1.2.3.5",
+		"disableFlag": false
+	}],
+	"geolocation": null,
+	"recordFailover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"failover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"roundRobinFailover": [],
+	"pools": [],
+	"poolsDetail": []
+}]

--- a/tests/fixtures/constellix-records.json
+++ b/tests/fixtures/constellix-records.json
@@ -65,7 +65,7 @@
 	"pools": [],
 	"poolsDetail": []
 }, {
-	"id": 1808527,
+	"id": 1808526,
 	"type": "SRV",
 	"recordType": "srv",
 	"name": "_srv._tcp",
@@ -133,7 +133,7 @@
 		"disableFlag": false
 	}]
 }, {
-	"id": 1808527,
+	"id": 1808528,
 	"type": "SRV",
 	"recordType": "srv",
 	"name": "_pop3._tcp",
@@ -580,7 +580,7 @@
 	"pools": [],
 	"poolsDetail": []
 }, {
-	"id": 1808520,
+	"id": 1808510,
 	"type": "A",
 	"recordType": "a",
 	"name": "www.sub",
@@ -615,6 +615,46 @@
 	"pools": [],
 	"poolsDetail": []
 }, {
+	"id": 1808518,
+	"type": "A",
+	"recordType": "a",
+	"name": "www.dynamic",
+	"recordOption": "roundRobin",
+	"noAnswer": false,
+	"note": "",
+	"ttl": 300,
+	"gtdRegion": 1,
+	"parentId": 123123,
+	"parent": "domain",
+	"source": "Domain",
+	"modifiedTs": 1565150090588,
+	"value": ["2.2.3.4","2.2.3.5"],
+	"roundRobin": [{
+		"value": "2.2.3.4",
+		"disableFlag": false
+	}, {
+		"value": "2.2.3.5",
+		"disableFlag": false
+	}],
+	"geolocation": {
+		"geoipFilter": 1
+	},
+	"recordFailover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"failover": {
+		"disabled": false,
+		"failoverType": 1,
+		"failoverTypeStr": "Normal (always lowest level)",
+		"values": []
+	},
+	"roundRobinFailover": [],
+	"pools": [],
+	"poolsDetail": []
+}, {
 	"id": 1808520,
 	"type": "A",
 	"recordType": "a",
@@ -631,7 +671,7 @@
 	"value": [],
 	"roundRobin": [],
 	"geolocation": {
-		"geoipFilter": 1
+		"geoipFilter": 9303
 	},
 	"recordFailover": {
 		"disabled": false,


### PR DESCRIPTION
Fixes https://github.com/octodns/octodns/issues/825.
Checked against the real constellix API.

- the global default is now modeled without using a pool (this will allow for pool manipulation without ever touching the fallback value later on)
- disentangled pool from rule handling in preparation of "safe" updates
- added some fixtures
- only the non-pooled global default is allowed to ever user the immutable geofilter with id=1
- checks added for unsupported configurations (e.g. multiple entries for multiple GTD regions)
- checks added to assure that `fallback` has `healthcheck` configured and drop `fallback` requests without `healthcheck` in place
- checks added for unsupported geo configurations (multiple non-pool records with geofilter set)

There are lots of changes. It would be great if @yzguy and/or @viranch could check the feasability of this PR with some other real configuration.
There is still some amount of work needed to strengthen and augment the test harness. I will work on this in subsequent PRs.