### PR TITLE
Add python 3.10 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches, 
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ ConstellixProvider supports A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF
 
 ConstellixProvider supports dynamic records.
 
-### Developement
+### Development
 
 See the [/script/](/script/) directory for some tools to help with the development process. They generally follow the [Script to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern. Most useful is `./script/bootstrap` which will create a venv and install both the runtime and development related requirements. It will also hook up a pre-commit hook that covers most of what's run by CI.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,13 +5,12 @@ colorama==0.4.4
 docutils==0.18.1
 importlib-metadata==4.8.3
 keyring==23.4.1
-nose-no-network==0.0.1
-nose-timer==1.0.1
-nose==1.3.7
 pep517==0.12.0
 pkginfo==1.8.2
 pycodestyle==2.6.0
 pyflakes==2.2.0
+pytest
+pytest-network
 readme-renderer==32.0
 requests-mock==1.9.3
 requests-toolbelt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ PyYAML==6.0
 attrs==21.4.0
 certifi==2021.10.8
 charset-normalizer==2.0.10
-coverage==6.2
 dnspython==2.1.0
 fqdn==1.5.1
 idna==3.3

--- a/script/coverage
+++ b/script/coverage
@@ -38,11 +38,12 @@ grep -r -I --line-number "# pragma: +no.*cover" $SOURCE_DIR && {
   exit 1
 }
 
-coverage run --branch --source=$SOURCE_DIR "$(command -v nosetests)" --with-no-network --with-xunit "$@"
-coverage html
-coverage xml
-coverage report --show-missing
-coverage report | grep ^TOTAL | grep -qv 100% && {
-    echo "Incomplete code coverage" >&2
-    exit 1
-} || echo "Code coverage 100%"
+pytest \
+        --cov-reset \
+        --cov=$SOURCE_DIR \
+        --cov-fail-under=100 \
+        --cov-report=html \
+        --cov-report=xml \
+        --cov-report=term \
+        --cov-branch \
+        tests.py

--- a/script/coverage
+++ b/script/coverage
@@ -38,6 +38,8 @@ grep -r -I --line-number "# pragma: +no.*cover" $SOURCE_DIR && {
   exit 1
 }
 
+export PYTHONPATH=.:$PYTHONPATH
+
 pytest \
         --disable-network \
         --cov-reset \
@@ -47,4 +49,4 @@ pytest \
         --cov-report=xml \
         --cov-report=term \
         --cov-branch \
-        tests.py
+        "$@"

--- a/script/coverage
+++ b/script/coverage
@@ -39,6 +39,7 @@ grep -r -I --line-number "# pragma: +no.*cover" $SOURCE_DIR && {
 }
 
 pytest \
+        --disable-network \
         --cov-reset \
         --cov=$SOURCE_DIR \
         --cov-fail-under=100 \

--- a/script/lint
+++ b/script/lint
@@ -15,7 +15,7 @@ if [ ! -f "$ACTIVATE" ]; then
 fi
 . "$ACTIVATE"
 
-SOURCES="octodns_*/*.py setup.py tests.py"
+SOURCES="octodns_*/*.py setup.py tests/*.py"
 
 pycodestyle --ignore=E221,E241,E251,E722,E741,W504 $SOURCES
 pyflakes $SOURCES

--- a/script/test
+++ b/script/test
@@ -30,4 +30,6 @@ export ARM_CLIENT_SECRET=
 export ARM_TENANT_ID=
 export ARM_SUBSCRIPTION_ID=
 
-nosetests --with-no-network "$@"
+export PYTHONPATH=.:$PYTHONPATH
+
+pytest --disable-network tests.py

--- a/script/test
+++ b/script/test
@@ -32,4 +32,4 @@ export ARM_SUBSCRIPTION_ID=
 
 export PYTHONPATH=.:$PYTHONPATH
 
-pytest --disable-network tests.py
+pytest --disable-network "$@"

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
     url='https://github.com/octodns/octodns-constellix',
     version=version(),
     tests_require=(
-        'nose',
-        'nose-no-network',
-        'rquests_mock'
+        'pytest',
+        'pytest-network',
     ),
 )

--- a/tests.py
+++ b/tests.py
@@ -286,7 +286,7 @@ class TestConstellixProvider(TestCase):
             with self.assertRaises(Exception) as ctx:
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-            self.assertEquals('Unauthorized', str(ctx.exception))
+            self.assertEqual('Unauthorized', str(ctx.exception))
 
         with requests_mock() as mock:
             mock.get(ANY, status_code=401,
@@ -294,7 +294,7 @@ class TestConstellixProvider(TestCase):
 
             with self.assertRaises(Exception) as ctx:
                 provider._sonar.agents
-            self.assertEquals('Unauthorized', str(ctx.exception))
+            self.assertEqual('Unauthorized', str(ctx.exception))
 
         # Bad request
         with requests_mock() as mock:
@@ -305,8 +305,8 @@ class TestConstellixProvider(TestCase):
             with self.assertRaises(Exception) as ctx:
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-            self.assertEquals('\n  - "unittests" is not a valid domain name',
-                              str(ctx.exception))
+            self.assertEqual('\n  - "unittests" is not a valid domain name',
+                             str(ctx.exception))
 
         with requests_mock() as mock:
             mock.get(ANY, status_code=400,
@@ -314,8 +314,8 @@ class TestConstellixProvider(TestCase):
 
             with self.assertRaises(Exception) as ctx:
                 provider._sonar.agents
-            self.assertEquals('\n  - error text',
-                              str(ctx.exception))
+            self.assertEqual('\n  - error text',
+                             str(ctx.exception))
 
         # General error
         with requests_mock() as mock:
@@ -324,7 +324,7 @@ class TestConstellixProvider(TestCase):
             with self.assertRaises(HTTPError) as ctx:
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-            self.assertEquals(502, ctx.exception.response.status_code)
+            self.assertEqual(502, ctx.exception.response.status_code)
 
         # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
@@ -333,20 +333,20 @@ class TestConstellixProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEquals(set(), zone.records)
+            self.assertEqual(set(), zone.records)
 
         with requests_mock() as mock:
             mock.get(ANY, status_code=404, text='')
             with self.assertRaises(Exception) as ctx:
                 provider._sonar.agents
-            self.assertEquals('Not Found', str(ctx.exception))
+            self.assertEqual('Not Found', str(ctx.exception))
 
         # Sonar Normal response
         provider = ConstellixProvider('test', 'api', 'secret')
         with requests_mock() as mock:
             mock.get(ANY, status_code=200, text='[]')
             agents = provider._sonar.agents
-            self.assertEquals({}, agents)
+            self.assertEqual({}, agents)
             agents = provider._sonar.agents
 
         provider = ConstellixProvider('test', 'api', 'secret', 0.01)
@@ -374,14 +374,14 @@ class TestConstellixProvider(TestCase):
 
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-                self.assertEquals(17, len(zone.records))
+                self.assertEqual(17, len(zone.records))
                 changes = self.expected_dynamic.changes(zone, provider)
-                self.assertEquals(0, len(changes))
+                self.assertEqual(0, len(changes))
 
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEquals(17, len(again.records))
+        self.assertEqual(17, len(again.records))
 
         # bust the cache
         del provider._zone_records[zone.name]
@@ -411,8 +411,8 @@ class TestConstellixProvider(TestCase):
 
         # No root NS, no ignored, no excluded, no unsupported
         n = len(self.expected.records) - 8
-        self.assertEquals(n, len(plan.changes))
-        self.assertEquals(n, provider.apply(plan))
+        self.assertEqual(n, len(plan.changes))
+        self.assertEqual(n, provider.apply(plan))
 
         provider._client._request.assert_has_calls([
             # get all domains to build the cache
@@ -463,7 +463,7 @@ class TestConstellixProvider(TestCase):
             }),
         ])
 
-        self.assertEquals(22, provider._client._request.call_count)
+        self.assertEqual(22, provider._client._request.call_count)
 
         provider._client._request.reset_mock()
 
@@ -569,8 +569,8 @@ class TestConstellixProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(4, len(plan.changes))
-        self.assertEquals(4, provider.apply(plan))
+        self.assertEqual(4, len(plan.changes))
+        self.assertEqual(4, provider.apply(plan))
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
@@ -672,8 +672,8 @@ class TestConstellixProvider(TestCase):
 
         # No root NS, no ignored, no excluded, no unsupported
         n = len(self.expected_healthcheck.records) - 8
-        self.assertEquals(n, len(plan.changes))
-        self.assertEquals(n, provider.apply(plan))
+        self.assertEqual(n, len(plan.changes))
+        self.assertEqual(n, provider.apply(plan))
 
         provider._client._request.assert_has_calls([
             # get all domains to build the cache
@@ -728,7 +728,7 @@ class TestConstellixProvider(TestCase):
             }),
         ])
 
-        self.assertEquals(22, provider._client._request.call_count)
+        self.assertEqual(22, provider._client._request.call_count)
 
         provider._client._request.reset_mock()
 
@@ -834,8 +834,8 @@ class TestConstellixProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(4, len(plan.changes))
-        self.assertEquals(4, provider.apply(plan))
+        self.assertEqual(4, len(plan.changes))
+        self.assertEqual(4, provider.apply(plan))
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
@@ -924,8 +924,8 @@ class TestConstellixProvider(TestCase):
 
         # No root NS, no ignored, no excluded, no unsupported
         n = len(self.expected_healthcheck.records) - 8
-        self.assertEquals(n, len(plan.changes))
-        self.assertEquals(n, provider.apply(plan))
+        self.assertEqual(n, len(plan.changes))
+        self.assertEqual(n, provider.apply(plan))
 
         provider._client._request.assert_has_calls([
             # get all domains to build the cache
@@ -980,7 +980,7 @@ class TestConstellixProvider(TestCase):
             }),
         ])
 
-        self.assertEquals(22, provider._client._request.call_count)
+        self.assertEqual(22, provider._client._request.call_count)
 
         provider._client._request.reset_mock()
 
@@ -1086,8 +1086,8 @@ class TestConstellixProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(4, len(plan.changes))
-        self.assertEquals(4, provider.apply(plan))
+        self.assertEqual(4, len(plan.changes))
+        self.assertEqual(4, provider.apply(plan))
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
@@ -1166,8 +1166,8 @@ class TestConstellixProvider(TestCase):
 
         # No root NS, no ignored, no excluded, no unsupported
         n = len(self.expected_dynamic.records) - 8
-        self.assertEquals(n, len(plan.changes))
-        self.assertEquals(n, provider.apply(plan))
+        self.assertEqual(n, len(plan.changes))
+        self.assertEqual(n, provider.apply(plan))
 
         provider._client._request.assert_has_calls([
             # get all domains to build the cache
@@ -1239,7 +1239,7 @@ class TestConstellixProvider(TestCase):
             }),
         ])
 
-        self.assertEquals(28, provider._client._request.call_count)
+        self.assertEqual(28, provider._client._request.call_count)
 
         provider._client._request.reset_mock()
 
@@ -1413,8 +1413,8 @@ class TestConstellixProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(4, len(plan.changes))
-        self.assertEquals(4, provider.apply(plan))
+        self.assertEqual(4, len(plan.changes))
+        self.assertEqual(4, provider.apply(plan))
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
@@ -1728,8 +1728,8 @@ class TestConstellixProvider(TestCase):
                       text='[{"id": 1234}]')
 
             plan = provider.plan(wanted)
-            self.assertEquals(1, len(plan.changes))
-            self.assertEquals(1, provider.apply(plan))
+            self.assertEqual(1, len(plan.changes))
+            self.assertEqual(1, provider.apply(plan))
 
             provider._client.geofilters = Mock(return_value=[
                 {
@@ -1747,8 +1747,8 @@ class TestConstellixProvider(TestCase):
             ])
 
             plan = provider.plan(wanted)
-            self.assertEquals(1, len(plan.changes))
-            self.assertEquals(1, provider.apply(plan))
+            self.assertEqual(1, len(plan.changes))
+            self.assertEqual(1, provider.apply(plan))
 
             provider._client.geofilters = Mock(return_value=[
                 {
@@ -1760,8 +1760,8 @@ class TestConstellixProvider(TestCase):
             ])
 
             plan = provider.plan(wanted)
-            self.assertEquals(1, len(plan.changes))
-            self.assertEquals(1, provider.apply(plan))
+            self.assertEqual(1, len(plan.changes))
+            self.assertEqual(1, provider.apply(plan))
 
         # Now what happens if an error happens that we can't handle
         # geofilter case
@@ -1789,7 +1789,7 @@ class TestConstellixProvider(TestCase):
                       text='[{"id": 1234}]')
 
             plan = provider.plan(wanted)
-            self.assertEquals(1, len(plan.changes))
+            self.assertEqual(1, len(plan.changes))
             with self.assertRaises(ConstellixClientBadRequest):
                 provider.apply(plan)
 
@@ -1818,7 +1818,7 @@ class TestConstellixProvider(TestCase):
                       text='[{"id": 1234}]')
 
             plan = provider.plan(wanted)
-            self.assertEquals(1, len(plan.changes))
+            self.assertEqual(1, len(plan.changes))
             with self.assertRaises(ConstellixClientBadRequest):
                 provider.apply(plan)
 
@@ -1885,8 +1885,8 @@ class TestConstellixProvider(TestCase):
         }])
 
         a_pool = provider._client.pool('A', 'unit.tests.:www.dynamic:A:two')
-        self.assertEquals(42, a_pool['id'])
+        self.assertEqual(42, a_pool['id'])
 
         aaaa_pool = provider._client.pool('AAAA',
                                           'unit.tests.:www.dynamic:A:two')
-        self.assertEquals(451, aaaa_pool['id'])
+        self.assertEqual(451, aaaa_pool['id'])

--- a/tests/test_provider_constellix.py
+++ b/tests/test_provider_constellix.py
@@ -17,7 +17,7 @@ from octodns_constellix import ConstellixProvider, ConstellixClientBadRequest
 
 class TestConstellixProvider(TestCase):
     expected = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'tests', 'config'))
+    source = YamlProvider('test', join(dirname(__file__), 'config'))
     source.populate(expected)
 
     # Our test suite differs a bit, add our NS and remove the simple one
@@ -69,7 +69,7 @@ class TestConstellixProvider(TestCase):
             break
 
     expected_healthcheck = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'tests', 'config'))
+    source = YamlProvider('test', join(dirname(__file__), 'config'))
     source.populate(expected_healthcheck)
 
     # Our test suite differs a bit, add our NS and remove the simple one
@@ -135,7 +135,7 @@ class TestConstellixProvider(TestCase):
             break
 
     expected_healthcheck_world = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'tests', 'config'))
+    source = YamlProvider('test', join(dirname(__file__), 'config'))
     source.populate(expected_healthcheck_world)
 
     # Our test suite differs a bit, add our NS and remove the simple one
@@ -204,7 +204,7 @@ class TestConstellixProvider(TestCase):
             break
 
     expected_dynamic = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'tests', 'config'))
+    source = YamlProvider('test', join(dirname(__file__), 'config'))
     source.populate(expected_dynamic)
 
     # Our test suite differs a bit, add our NS and remove the simple one


### PR DESCRIPTION
@ross Note that we can (and should) drop the coverage package as well, because pytest comes with full coverage support.