### PR TITLE
Version 0.0.3 bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.0.3 - 2022-11-28 - implicit fallback leads to changes
+
+* fix fallback attribute in dynamic to no longer be implicit
+* align provider with SUPPORTS_ROOT_NS feature requirements
+* remove params to `super()` calls
+* multiple dependency version updates
+* miscellaneous script/tooling improvements
+
 ## v0.0.2 - 2022-02-02 - pycountry-convert install_requires
 
 * install_requires includes pycountry-convert as it's a runtime requirement

--- a/octodns_constellix/__init__.py
+++ b/octodns_constellix/__init__.py
@@ -15,7 +15,7 @@ from octodns.record import Record
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 class ConstellixClientException(ProviderException):


### PR DESCRIPTION
## v0.0.3 - 2022-11-28 - implicit fallback leads to changes

* fix fallback attribute in dynamic to no longer be implicit
* align provider with SUPPORTS_ROOT_NS feature requirements
* remove params to `super()` calls
* multiple dependency version updates
* miscellaneous script/tooling improvements

/cc @istr 