### PR TITLE
Python 3.12 tooling updates

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,5 +27,7 @@ requests-mock==1.11.0
 requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.6.0
+setuptools==68.2.2
 twine==4.0.2
+wheel==0.41.2
 zipp==3.17.0

--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -7,6 +7,7 @@ echo "## create test venv ######################################################
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
 python3 -m venv $TMP_DIR
 . "$TMP_DIR/bin/activate"
+pip install setuptools
 echo "## environment & versions ######################################################"
 python --version
 pip --version


### PR DESCRIPTION
setuptools and wheel are no longer part of venvs by default as of 3.12 and
needs to be explicitly installed when needed.

/cc https://github.com/octodns/octodns/pull/1085