### PR TITLE
Drop SPF support and replace it with TXT records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.x - 2023-10-xx - remove support for SPF records
+
+* Replace SPF records with TXT records to prepare for octodns v2
+
 ## v0.0.4 - 2023-09-24 - ordering is important
 
 * Fix for presistent changes in dynamic rule ordering

--- a/octodns_constellix/__init__.py
+++ b/octodns_constellix/__init__.py
@@ -456,19 +456,7 @@ class ConstellixProvider(BaseProvider):
     SUPPORTS_DYNAMIC = True
     SUPPORTS_ROOT_NS = False
     SUPPORTS = set(
-        (
-            'A',
-            'AAAA',
-            'ALIAS',
-            'CAA',
-            'CNAME',
-            'MX',
-            'NS',
-            'PTR',
-            'SPF',
-            'SRV',
-            'TXT',
-        )
+        ('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT')
     )
 
     def __init__(
@@ -667,8 +655,6 @@ class ConstellixProvider(BaseProvider):
         ]
         return {'ttl': records[0]['ttl'], 'type': _type, 'values': values}
 
-    _data_for_SPF = _data_for_TXT
-
     def _data_for_MX(self, _type, records):
         values = []
         record = records[0]
@@ -832,8 +818,6 @@ class ConstellixProvider(BaseProvider):
         for value in record.chunked_values:
             values.append({'value': value.replace('\\;', ';')})
         yield {'name': record.name, 'ttl': record.ttl, 'roundRobin': values}
-
-    _params_for_SPF = _params_for_TXT
 
     def _params_for_CAA(self, record):
         values = []

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -155,7 +155,7 @@ ptr:
   values: [foo.bar.com.]
 spf:
   ttl: 600
-  type: SPF
+  type: TXT
   value: v=spf1 ip4:192.168.0.1/16-all
 sub:
   type: 'NS'

--- a/tests/fixtures/constellix-records.json
+++ b/tests/fixtures/constellix-records.json
@@ -438,7 +438,7 @@
 	}]
 }, {
 	"id": 1808526,
-	"type": "SPF",
+	"type": "TXT",
 	"recordType": "spf",
 	"name": "spf",
 	"recordOption": "roundRobin",

--- a/tests/test_provider_constellix.py
+++ b/tests/test_provider_constellix.py
@@ -514,7 +514,7 @@ class TestConstellixProvider(TestCase):
                 ),
                 call(
                     'POST',
-                    '/domains/123123/records/SPF',
+                    '/domains/123123/records/TXT',
                     data={
                         'name': 'spf',
                         'ttl': 600,


### PR DESCRIPTION
Fixes #43. Prepare for `octodns` v2.