### PR TITLE
Implement Provider.list_zones for dynamic zone config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Use a common code base for ConstellixClient and SonarClient
 * Prepare the authZ code for v4 (Authorization: Bearer)
+* Support for Provider.list_zones to enable dynamic zone config when operating
+  as a source
 
 ## v0.0.4 - 2023-09-24 - ordering is important
 

--- a/octodns_constellix/__init__.py
+++ b/octodns_constellix/__init__.py
@@ -13,6 +13,7 @@ from pycountry_convert import country_alpha2_to_continent_code
 from requests import Session
 
 from octodns import __VERSION__ as octodns_version
+from octodns.idna import IdnaDict
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 from octodns.record import Record
@@ -134,7 +135,7 @@ class ConstellixClient(ConstellixAPI):
             resp = self._request('GET', '/domains').json()
             zones += resp
 
-            self._domains = {f'{z["name"]}.': z['id'] for z in zones}
+            self._domains = IdnaDict({f'{z["name"]}.': z['id'] for z in zones})
 
         return self._domains
 
@@ -680,6 +681,10 @@ class ConstellixProvider(BaseProvider):
                 return []
 
         return self._zone_records[zone.name]
+
+    def list_zones(self):
+        self.log.debug('list_zones:')
+        return sorted(self._client.domains.keys())
 
     def populate(self, zone, target=False, lenient=False):
         self.log.debug(

--- a/tests/test_provider_constellix.py
+++ b/tests/test_provider_constellix.py
@@ -260,6 +260,8 @@ class TestConstellixProvider(TestCase):
                 changes = expected.changes(zone, provider)
                 self.assertEqual(0, len(changes))
 
+            self.assertEqual(['unit.tests.'], provider.list_zones())
+
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
         provider.populate(again)


### PR DESCRIPTION
This also updates the domain cache to use `IdnaDict` to improve unicode domain support (may need other changes to fully do so.)

/cc https://github.com/octodns/octodns/pull/1026 for base functionality that will utilize this
/cc https://github.com/octodns/octodns/issues/1025 for tracking the work
/cc @istr as I don't have access to test w/the actual provider, but this should be a fairly safe change since it's re-using an existing mechinism