### PR TITLE
pytest warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,7 @@ line_length=80
 sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    'error',
+]
 pythonpath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,6 @@ filterwarnings = [
     'error',
     # pycountry_mappings -> repoze.lru ->
     'ignore:pkg_resources is deprecated',
+    'ignore:Deprecated call to `pkg_resources.declare_namespace',
 ]
 pythonpath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,7 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    # pycountry_mappings -> repoze.lru ->
+    'ignore:pkg_resources is deprecated',
 ]
 pythonpath = "."


### PR DESCRIPTION
Bump python warnings to error during pytest, and fix any existing warnings

/cc octodns/octodns#1108
