### PR TITLE
Ignore deprecation warnings during tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    # TODO: remove once octodns 2.0 has been released
+    'ignore:.*DEPRECATED.*2.0',
     # pycountry_mappings -> repoze.lru ->
     'ignore:pkg_resources is deprecated',
     'ignore:Deprecated call to `pkg_resources.declare_namespace',


### PR DESCRIPTION
Tell pytest to ignore deprecation warnings when erroring on warnings during pytests.

/cc https://github.com/octodns/octodns/pull/1112
