### PR TITLE
Bump required octodns >= 1.5, address pending deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.0.0 - 2024-??-?? - ???
+
+Noteworthy Changes:
+
+* Complete removal of SPF record support, records should be transitioned to TXT
+  values before updating to this version.
+
+Changes:
+
+* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
+
 ## v0.0.5 - 2024-06-20 - refactor API code
 
 * Use a common code base for ConstellixClient and SonarClient

--- a/octodns_constellix/__init__.py
+++ b/octodns_constellix/__init__.py
@@ -431,19 +431,7 @@ class ConstellixProvider(BaseProvider):
     SUPPORTS_DYNAMIC = True
     SUPPORTS_ROOT_NS = False
     SUPPORTS = set(
-        (
-            'A',
-            'AAAA',
-            'ALIAS',
-            'CAA',
-            'CNAME',
-            'MX',
-            'NS',
-            'PTR',
-            'SPF',
-            'SRV',
-            'TXT',
-        )
+        ('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT')
     )
 
     def __init__(
@@ -643,8 +631,6 @@ class ConstellixProvider(BaseProvider):
         ]
         return {'ttl': records[0]['ttl'], 'type': _type, 'values': values}
 
-    _data_for_SPF = _data_for_TXT
-
     def _data_for_MX(self, _type, records):
         values = []
         record = records[0]
@@ -727,13 +713,13 @@ class ConstellixProvider(BaseProvider):
         return exists
 
     def _is_healthcheck_configured(self, record):
-        sonar_healthcheck = record._octodns.get('constellix', {}).get(
+        sonar_healthcheck = record.octodns.get('constellix', {}).get(
             'healthcheck', None
         )
         return sonar_healthcheck is not None
 
     def _healthcheck_config(self, record):
-        sonar_healthcheck = record._octodns.get('constellix', {}).get(
+        sonar_healthcheck = record.octodns.get('constellix', {}).get(
             'healthcheck', None
         )
 
@@ -814,8 +800,6 @@ class ConstellixProvider(BaseProvider):
                 {'value': value.replace('\\;', ';').replace('" "', '""')}
             )
         yield {'name': record.name, 'ttl': record.ttl, 'roundRobin': values}
-
-    _params_for_SPF = _params_for_TXT
 
     def _params_for_CAA(self, record):
         values = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    # TODO: remove once octodns 2.0 has been released
-    'ignore:.*DEPRECATED.*2.0',
     # pycountry_mappings -> repoze.lru ->
     'ignore:pkg_resources is deprecated',
     'ignore:Deprecated call to `pkg_resources.declare_namespace',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'test': tests_require,
     },
     install_requires=(
-        'octodns>=0.9.14',
+        'octodns>=1.5.0',
         'pycountry-convert>=0.7.2',
         'requests>=2.27.0',
     ),

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -1,19 +1,6 @@
 ---
 ? ''
-: - geo:
-      AF:
-      - 2.2.3.4
-      - 2.2.3.5
-      AS-JP:
-      - 3.2.3.4
-      - 3.2.3.5
-      NA-US:
-      - 4.2.3.4
-      - 4.2.3.5
-      NA-US-CA:
-      - 5.2.3.4
-      - 5.2.3.5
-    ttl: 300
+: - ttl: 300
     type: A
     values:
     - 1.2.3.4
@@ -153,10 +140,6 @@ ptr:
   ttl: 300
   type: PTR
   values: [foo.bar.com.]
-spf:
-  ttl: 600
-  type: SPF
-  value: v=spf1 ip4:192.168.0.1/16-all
 sub:
   type: 'NS'
   values:

--- a/tests/fixtures/constellix-records.json
+++ b/tests/fixtures/constellix-records.json
@@ -437,28 +437,6 @@
 		"disableFlag": false
 	}]
 }, {
-	"id": 1808526,
-	"type": "SPF",
-	"recordType": "spf",
-	"name": "spf",
-	"recordOption": "roundRobin",
-	"noAnswer": false,
-	"note": "",
-	"ttl": 600,
-	"gtdRegion": 1,
-	"parentId": 123123,
-	"parent": "domain",
-	"source": "Domain",
-	"modifiedTs": 1565149916132,
-	"value": [{
-		"value": "\"v=spf1 ip4:192.168.0.1/16-all\"",
-		"disableFlag": false
-	}],
-	"roundRobin": [{
-		"value": "\"v=spf1 ip4:192.168.0.1/16-all\"",
-		"disableFlag": false
-	}]
-}, {
 	"id": 1808528,
 	"type": "TXT",
 	"recordType": "txt",

--- a/tests/test_provider_constellix.py
+++ b/tests/test_provider_constellix.py
@@ -35,9 +35,9 @@ class TestConstellixProvider(TestCase):
         # Add our NS record and remove the default test case.
         for record in list(expected.records):
             if record.name == 'sub' and record._type == 'NS':
-                expected._remove_record(record)
+                expected.remove_record(record)
             if record.name == '' and record._type == 'NS':
-                expected._remove_record(record)
+                expected.remove_record(record)
         expected.add_record(
             Record.new(
                 expected,
@@ -256,8 +256,9 @@ class TestConstellixProvider(TestCase):
 
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-                self.assertEqual(18, len(zone.records))
+                self.assertEqual(17, len(zone.records))
                 changes = expected.changes(zone, provider)
+                print(changes)
                 self.assertEqual(0, len(changes))
 
             self.assertEqual(['unit.tests.'], provider.list_zones())
@@ -265,7 +266,7 @@ class TestConstellixProvider(TestCase):
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEqual(18, len(again.records))
+        self.assertEqual(17, len(again.records))
 
         # Bust the cache.
         del provider._zone_records[zone.name]
@@ -319,22 +320,21 @@ class TestConstellixProvider(TestCase):
             [],
             [],
             [],
-            [],
         ]
         resp.json.side_effect = resp_side_effect
 
         plan = provider.plan(expected)
 
-        # 24 records given in unit.tests.yaml
+        # 23 records given in unit.tests.yaml
         #  1 ALIAS record added
         #  1 Root NS record removed by test setup
-        # 24 records exepected
+        # 23 records exepected
         #  1 ignored
         #  1 exclued
         #  5 unsupported: URLFWD, NAPTR, LOC, SSHFP, DNAME
         #  7 records not applied
         # 18 records applied
-        self.assertEqual(len(expected.records), 24)
+        self.assertEqual(len(expected.records), 23)
         n = len(expected.records) - 7
         self.assertEqual(n, len(plan.changes))
         self.assertEqual(n, provider.apply(plan))
@@ -514,17 +514,6 @@ class TestConstellixProvider(TestCase):
                         'ttl': 300,
                         'roundRobin': [
                             {'value': 'foo.bar.com.', 'disableFlag': False}
-                        ],
-                    },
-                ),
-                call(
-                    'POST',
-                    '/domains/123123/records/SPF',
-                    data={
-                        'name': 'spf',
-                        'ttl': 600,
-                        'roundRobin': [
-                            {'value': '"v=spf1 ip4:192.168.0.1/16-all"'}
                         ],
                     },
                 ),


### PR DESCRIPTION
Address deprecations happening in upcoming octoDNS 2.x

/cc https://github.com/octodns/octodns/issues/1215 for tracking
