### PR TITLE
Version 1.0.1 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/0e3eacf7f6df4108b343d200fb230c4d.md
+++ b/.changelog/0e3eacf7f6df4108b343d200fb230c4d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/18e7703d9d7947b4a230a8b03fa45464.md
+++ b/.changelog/18e7703d9d7947b4a230a8b03fa45464.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/5c342a646c664af3b80c2348b4035275.md
+++ b/.changelog/5c342a646c664af3b80c2348b4035275.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/8da1892d658f4dcd810616b93b452d73.md
+++ b/.changelog/8da1892d658f4dcd810616b93b452d73.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/964f8f9a76764fb482f173b7eaf89384.md
+++ b/.changelog/964f8f9a76764fb482f173b7eaf89384.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/a15e380115544395b7c516f475542659.md
+++ b/.changelog/a15e380115544395b7c516f475542659.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/c0ec5774ed5e4a449851624e21c3968b.md
+++ b/.changelog/c0ec5774ed5e4a449851624e21c3968b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/d945c5384c8e464da469c4d15f5a9019.md
+++ b/.changelog/d945c5384c8e464da469c4d15f5a9019.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2026-04-03
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#68](https://github.com/octodns/octodns-constellix/pull/68)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_constellix/__init__.py
+++ b/octodns_constellix/__init__.py
@@ -19,7 +19,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 class ConstellixAPIException(ProviderException):


### PR DESCRIPTION
## 1.0.1 - 2026-04-03

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#68](https://github.com/octodns/octodns-constellix/pull/68)

