### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/1781e3c4d881404c839d1e2db28cce47.md
+++ b/.changelog/1781e3c4d881404c839d1e2db28cce47.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -151,7 +151,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 txtchunked:
   ttl: 600
   type: TXT

--- a/tests/test_provider_constellix.py
+++ b/tests/test_provider_constellix.py
@@ -28,7 +28,9 @@ from octodns_constellix import (
 class TestConstellixProvider(TestCase):
     def populate_expected(self, zone_name):
         expected = Zone(zone_name, [])
-        source = YamlProvider('test', join(dirname(__file__), 'config'))
+        source = YamlProvider(
+            'test', join(dirname(__file__), 'config'), escaped_semicolons=False
+        )
         source.populate(expected)
 
         # Constellix does not allow IP addresses for NS entries.


### PR DESCRIPTION
YamlProvider is going to default to `escaped_semicolons=False` in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419